### PR TITLE
Enhance spacemacs erlang layer configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,73 +1,110 @@
 #+TITLE: erlang_ts layer
 
-#+TAGS: erlang|layer|edts|multi-paradigm|programming|erl-trace
+#+TAGS: erlang|layer|edts|lsp|programming|erl-trace
 
 [[img/erlang_ts.png]]
 
-# TOC links should be GitHub style anchors.
 * Table of Contents                                       :TOC_4_gh:noexport:
 - [[#description][Description]]
-  - [[#features][Features:]]
+  - [[#features][Features]]
 - [[#install][Install]]
+- [[#configuration][Configuration]]
+  - [[#layer-variables][Layer variables]]
+  - [[#optional-tools][Optional tools]]
 - [[#key-bindings][Key bindings]]
+- [[#troubleshooting][Troubleshooting]]
 
 * Description
-This layer adds Erlang to [[https://www.spacemacs.org/][Spacemacs]].
-Use [[https://github.com/sebastiw/edts][EDTS]] for code navigation. Also include other awesome packages such as erl-trace, company, flycheck, cmpload
+This layer adds Erlang development support to [[https://www.spacemacs.org/][Spacemacs]].
+It provides a sensible default setup for editing Erlang, optional code navigation
+backends (EDTS or LSP), on-the-fly syntax checking, and convenient helpers
+for tracing and common project tasks.
 
-** Features:
-  + [[https://www.erlang.org/][erlang]]: Programming language used to build massively scalable soft real-time systems with requirements on high availability.
-  + [[https://github.com/sebastiw/edts][edts]]: Erlang Development Tool Suite 
-  + [[https://develop.spacemacs.org/layers/+completion/auto-completion/README.html][company]] : Auto-completion to all supported language layers.
-  + [[https://github.com/flycheck/flycheck][flycheck]]: Modern on-the-fly syntax checking extension
-  + [[https://github.com/datttnwork7247/cmpload][cmpload]]: My erlang live code update tool
-  + [[https://github.com/datttnwork7247/erl-trace][erl-trace]] : My simple erlang debug tool by put io:format in erlang files
+** Features
+- =erlang=: Major mode for Erlang with indentation, imenu, skeletons, and REPL.
+- =company=: Auto-completion via company backends.
+- =flycheck=: On-the-fly syntax checking when the =syntax-checking= layer is used.
+- =EDTS=: Erlang Development Tool Suite for navigation and refactoring (optional).
+- =LSP=: Use =erlang_ls= through the Spacemacs =lsp= layer (optional).
+- =erl-trace=: Quick insertion of =io:format= traces and helpers (optional).
+- =rebar3= helpers: Compile, test and run dialyzer directly from Spacemacs.
+- =cmpload=: Live code update helper (optional).
 
 * Install
-
-Clone the layer to your spacemacs private directory
-  #+BEGIN_SRC bash
-  git clone https://github.com/datttnwork7247/erlang_ts.git ~/.emacs.d/private/erlang_ts
-  #+END_SRC
-
-To use this configuration layer, add it to your =~/.spacemacs=. You will need to
-add =erlang_ts= to the existing =dotspacemacs-configuration-layers= list in this
-file.
-
+Clone the layer to your Spacemacs private layers directory:
 #+BEGIN_SRC bash
-(setq-default dotspacemacs-configuration-layers
-              '(erlang_ts))
+git clone https://github.com/datttnwork7247/erlang_ts.git ~/.emacs.d/private/erlang_ts
 #+END_SRC
 
+Enable the layer in your =~/.spacemacs=:
+#+BEGIN_SRC emacs-lisp
+(setq-default dotspacemacs-configuration-layers
+              '(
+                ;; optional, for LSP support
+                ;; (lsp :variables lsp-enable-file-watchers nil)
+                ;; optional, for completion and flycheck
+                auto-completion
+                syntax-checking
+
+                ;; this layer
+                erlang_ts))
+#+END_SRC
+
+* Configuration
+** Layer variables
+You can customize the behavior via these variables (set them in the
+=dotspacemacs/user-config= section or as layer variables):
+
+- =erlang_ts-backend=: backend for navigation and xref. One of =xref= (default),
+  =edts=, or =lsp=. When set to =lsp=, enable the Spacemacs =lsp= layer and install
+  =erlang_ls=.
+- =erlang_ts-enable-edts=: install and enable EDTS integration (default: =t=).
+- =erlang_ts-enable-erl-trace=: enable =erl-trace= helpers (default: =t=).
+- =erlang_ts-enable-cmpload=: enable =cmpload= helpers (default: =nil=).
+- =erlang_ts-rebar3-command=: command used to invoke rebar3 (default: ="rebar3"=).
+
+Example:
+#+BEGIN_SRC emacs-lisp
+(setq erlang_ts-backend 'lsp
+      erlang_ts-enable-edts nil
+      erlang_ts-enable-erl-trace t
+      erlang_ts-rebar3-command "rebar3")
+#+END_SRC
+
+** Optional tools
+- EDTS: [[https://github.com/sebastiw/edts][sebastiw/edts]]
+- LSP: [[https://github.com/erlang-ls/erlang_ls][erlang_ls]] and Spacemacs =lsp= layer
+- erl-trace: [[https://github.com/datttnwork7247/erl-trace][datttnwork7247/erl-trace]]
+- cmpload: [[https://github.com/datttnwork7247/cmpload][datttnwork7247/cmpload]]
 
 * Key bindings
-** erlang_ts
-| Key binding | Description                                                     |
-|-------------+-----------------------------------------------------------------|
-| ~C-c C-a~   | Align arrows ("->")                                             |
-| ~C-c C-c~   | Comment region                                                  |
-| ~C-c C-d~   | Display function manual at point                                |
-| ~C-c C-j~   | Generate a new clause                                           |
-| ~C-c C-q~   | Indent function                                                 |
-| ~C-c C-u~   | Uncomment region                                                |
-| ~C-c C-y~   | Insert, at the point, the argument list of the previous clause. |
-| ~C-c C-z~   | Display the erlang-shell or start a new                         |
-| ~C-c M-a~   | Move backward to previous start of clause.                      |
-| ~C-c M-e~   | Move to the end of the current clause.                          |
-| ~C-c M-h~   | Put mark at end of clause, point at beginning.                  |
+** Navigation
+| Key binding | Description           |
+|-------------+-----------------------|
+| ~SPC m g d~ | Goto definition       |
+| ~SPC m g b~ | Go back               |
+| ~M .~       | Goto definition (EDTS/xref/LSP) |
+| ~M ,~       | Go back               |
 
-** EDTS
-| Key binding | Description                  |
-|-------------+------------------------------|
-| ~M .~       | EDTS find source under point |
-| ~M <comma>~ | EDTS find source unwind      |
-| ~C-c C-d w~ | EDTS find who call           |
-| ~C-c C-d~   | EDTS extra commands          |
+** Trace (erl-trace)
+| Key binding  | Description                                 |
+|--------------+---------------------------------------------|
+| ~SPC m t i~  | Insert trace at point                       |
+| ~SPC m t e~  | Extra commands (run cmd)                    |
+| ~SPC m t r~  | Store parameters for insertion              |
 
-** erl-trace
-| Key binding | Description                                 |
-|-------------+---------------------------------------------|
-| ~C-c C-t~   | erl-trace insert trace under clause         |
-| ~C-c C-e~   | erl-trace extra commands                    |
-| ~C-c C-r~   | erl-trace store parameter (used in C-c C-t) |
+** Build (rebar3)
+| Key binding  | Description             |
+|--------------+-------------------------|
+| ~SPC m b c~  | rebar3 compile          |
+| ~SPC m b t~  | rebar3 eunit            |
+| ~SPC m b d~  | rebar3 dialyzer         |
+
+* Troubleshooting
+- Package not found errors: this layer uses explicit recipes for =edts=, =erl-trace=
+  and =cmpload= to avoid ELPA/MELPA gaps. Ensure your network is available on the
+  first startup so Spacemacs can fetch them.
+- EDTS issues: EDTS requires an Erlang/OTP installation and a running node. If you
+  encounter initialization errors, try switching =erlang_ts-backend= to =xref= or =lsp=
+  until EDTS is set up.
 

--- a/config.el
+++ b/config.el
@@ -1,0 +1,18 @@
+;;; config.el --- erlang_ts layer configuration file for Spacemacs.
+
+(defvar erlang_ts-backend 'xref
+  "Backend to use for navigation and xref:
+Possible values are 'xref (default), 'edts or 'lsp.
+When set to 'lsp, ensure the Spacemacs lsp layer is enabled and erlang_ls is installed.")
+
+(defvar erlang_ts-enable-edts t
+  "If non-nil, install and enable EDTS integration.")
+
+(defvar erlang_ts-enable-erl-trace t
+  "If non-nil, install and enable erl-trace helper commands.")
+
+(defvar erlang_ts-enable-cmpload nil
+  "If non-nil, install and enable cmpload helper commands.")
+
+(defvar erlang_ts-rebar3-command "rebar3"
+  "Command used to invoke rebar3.")

--- a/funcs.el
+++ b/funcs.el
@@ -1,0 +1,108 @@
+;;; funcs.el --- erlang_ts layer functions file for Spacemacs.
+
+(defun erlang_ts//maybe-run-prog-hooks ()
+  "Run prog-mode hooks for buffers in erlang-mode.
+Erlang mode is not derived from prog-mode so we trigger them explicitly."
+  (if (fboundp 'spacemacs/run-prog-mode-hooks)
+      (spacemacs/run-prog-mode-hooks)
+    (run-hooks 'prog-mode-hook)))
+
+(defun erlang_ts//setup-backend ()
+  "Setup backend for Erlang according to `erlang_ts-backend'."
+  (pcase erlang_ts-backend
+    ('lsp (when (and (boundp 'lsp-mode) (fboundp 'lsp-deferred))
+            (lsp-deferred)))
+    ('edts (when (fboundp 'edts-mode)
+             (edts-mode 1)))
+    (_ nil)))
+
+(defun erlang_ts//setup-company ()
+  "Setup company backend for Erlang buffers."
+  (when (or (featurep 'company)
+            (configuration-layer/layer-used-p 'auto-completion))
+    (let ((setup
+           (lambda ()
+             (set (make-local-variable 'company-backends)
+                  (cond
+                   ((eq erlang_ts-backend 'lsp)
+                    '(company-capf))
+                   (t
+                    '(company-dabbrev-code company-files)))))))
+      (add-hook 'erlang-mode-hook setup))))
+
+(defun erlang_ts/goto-definition ()
+  "Go to definition using the configured backend."
+  (interactive)
+  (pcase erlang_ts-backend
+    ('edts (if (fboundp 'edts-find-source-under-point)
+               (edts-find-source-under-point)
+             (message "EDTS is not available")))
+    ('lsp (cond
+           ((fboundp 'lsp-find-definition) (lsp-find-definition))
+           ((fboundp 'xref-find-definitions) (call-interactively 'xref-find-definitions))
+           (t (message "No definition function available"))))
+    (_ (if (fboundp 'xref-find-definitions)
+           (call-interactively 'xref-find-definitions)
+         (message "xref not available")))))
+
+(defun erlang_ts/goto-back ()
+  "Go back from definition, depending on backend."
+  (interactive)
+  (cond
+   ((and (eq erlang_ts-backend 'edts)
+         (fboundp 'edts-find-source-unwind))
+    (edts-find-source-unwind))
+   ((fboundp 'xref-pop-marker-stack)
+    (xref-pop-marker-stack))
+   (t (message "No pop-back function available"))))
+
+;; erl-trace wrappers (lazy load)
+(defun erlang_ts/erl-trace-insert ()
+  (interactive)
+  (if (require 'erl-trace nil t)
+      (call-interactively 'erl-trace-insert)
+    (message "erl-trace is not available")))
+
+(defun erlang_ts/erl-trace-run-cmd ()
+  (interactive)
+  (if (require 'erl-trace nil t)
+      (call-interactively 'erl-trace-run-cmd)
+    (message "erl-trace is not available")))
+
+(defun erlang_ts/erl-trace-store ()
+  (interactive)
+  (if (require 'erl-trace nil t)
+      (call-interactively 'erl-trace-store)
+    (message "erl-trace is not available")))
+
+;; cmpload wrappers (lazy load)
+(defun erlang_ts/cmpload-load ()
+  (interactive)
+  (if (require 'cmpload nil t)
+      (call-interactively 'cmpload-load)
+    (message "cmpload is not available")))
+
+(defun erlang_ts/cmpload-reload ()
+  (interactive)
+  (if (require 'cmpload nil t)
+      (call-interactively 'cmpload-reload)
+    (message "cmpload is not available")))
+
+(defun erlang_ts/cmpload-compile ()
+  (interactive)
+  (if (require 'cmpload nil t)
+      (call-interactively 'cmpload-compile)
+    (message "cmpload is not available")))
+
+;; rebar3 helpers
+(defun erlang_ts/rebar3-compile ()
+  (interactive)
+  (compile (format "%s compile" erlang_ts-rebar3-command)))
+
+(defun erlang_ts/rebar3-eunit ()
+  (interactive)
+  (compile (format "%s eunit" erlang_ts-rebar3-command)))
+
+(defun erlang_ts/rebar3-dialyzer ()
+  (interactive)
+  (compile (format "%s dialyzer" erlang_ts-rebar3-command)))

--- a/keybindings.el
+++ b/keybindings.el
@@ -1,0 +1,22 @@
+;;; keybindings.el --- erlang_ts layer key bindings
+
+(spacemacs/declare-prefix-for-mode 'erlang-mode "mg" "goto")
+(spacemacs/declare-prefix-for-mode 'erlang-mode "mb" "build")
+(spacemacs/declare-prefix-for-mode 'erlang-mode "mt" "trace")
+(spacemacs/declare-prefix-for-mode 'erlang-mode "mc" "cmpload")
+
+(spacemacs/set-leader-keys-for-major-mode 'erlang-mode
+  "g d" 'erlang_ts/goto-definition
+  "g b" 'erlang_ts/goto-back
+  "b c" 'erlang_ts/rebar3-compile
+  "b t" 'erlang_ts/rebar3-eunit
+  "b d" 'erlang_ts/rebar3-dialyzer
+  "t i" 'erlang_ts/erl-trace-insert
+  "t e" 'erlang_ts/erl-trace-run-cmd
+  "t r" 'erlang_ts/erl-trace-store)
+
+(with-eval-after-load 'evil
+  (with-eval-after-load 'erlang
+    (evil-define-key 'normal erlang-mode-map
+      (kbd "M-.") 'erlang_ts/goto-definition
+      (kbd "M-,") 'erlang_ts/goto-back)))

--- a/layers.el
+++ b/layers.el
@@ -1,0 +1,8 @@
+;;; layers.el --- erlang_ts layer dependencies
+
+(configuration-layer/declare-layers
+ '(
+   ;; optional supporting layers users may want
+   auto-completion
+   syntax-checking
+   ))

--- a/packages.el
+++ b/packages.el
@@ -22,70 +22,54 @@
 
 (defconst erlang_ts-packages
   '(
-    company
-    erlang
-    ;; my edts
-    edts
-    flycheck
-    ;; my erl-trace
-    (erl-trace :location (recipe
-                        :fetcherer github
-                        :repo "datttnwork7247/erl-trace"
-                        :file ("*")
-                        ))
+    (company :toggle (configuration-layer/layer-used-p 'auto-completion))
+    (flycheck :toggle (configuration-layer/layer-used-p 'syntax-checking))
+    (erlang :location elpa)
+    (edts :toggle erlang_ts-enable-edts
+          :location (recipe :fetcher github :repo "sebastiw/edts"))
+    (erl-trace :toggle erlang_ts-enable-erl-trace
+               :location (recipe
+                          :fetcher github
+                          :repo "datttnwork7247/erl-trace"
+                          :files ("*")))
+    (cmpload :toggle erlang_ts-enable-cmpload
+             :location (recipe
+                        :fetcher github
+                        :repo "datttnwork7247/cmpload"
+                        :files ("*")))
     )
-  )
+  "List of all packages to install and/or initialize for this layer.")
 
 (defun erlang_ts/post-init-company ()
   ;; backend specific
-  (add-hook 'erlang-mode-local-vars-hook #'spacemacs//erlang-setup-company))
+  (add-hook 'erlang-mode-local-vars-hook #'erlang_ts//setup-company))
+
+(defun erlang_ts/post-init-flycheck ()
+  (add-hook 'erlang-mode-hook #'flycheck-mode))
 
 (defun erlang_ts/init-erlang ()
   (use-package erlang
     :defer t
-    ;; explicitly run prog-mode hooks since erlang mode does is not
-    ;; derived from prog-mode major-mode
-    :hook (erlang-mode . spacemacs/run-prog-mode-hooks)
-    (erlang-mode . spacemacs//erlang-default)
-    (erlang-mode-local-vars . spacemacs//erlang-setup-backend)
+    ;; Erlang mode is not derived from prog-mode
+    :hook
+    ((erlang-mode . erlang_ts//maybe-run-prog-hooks)
+     (erlang-mode-local-vars . erlang_ts//setup-backend))
     :init
-    (progn
-      (setq erlang-compile-extra-opts '(debug_info)))
-    :config (require 'erlang-start)))
+    (setq erlang-compile-extra-opts '(debug_info))
+    :config
+    (require 'erlang-start)))
 
 (defun erlang_ts/init-edts ()
   (use-package edts
     :defer t
-    :init
-    (add-hook 'after-init-hook (lambda () (require 'edts-mode)))
-    :config
-    (spacemacs/declare-prefix-for-mode 'erlang-mode "mn" "navigate")
-    (spacemacs/set-leader-keys-for-major-mode 'erlang-mode
-      "M-." 'edts-find-source-under-point
-      "M-," 'edts-find-source-unwind
-      )
-    (evil-define-key 'normal erlang-mode-map
-      (kbd "s-.") 'edts-find-source-under-point
-      (kbd "s-,") 'edts-find-source-unwind)
-    ))
+    :commands (edts-mode edts-find-source-under-point edts-find-source-unwind)))
 
 (defun erlang_ts/init-erl-trace ()
   (use-package erl-trace
     :defer t
-    :init
-    (add-hook 'after-init-hook (lambda () (require 'erl-trace)))
-    :config
-    (spacemacs/set-leader-keys-for-major-mode 'erlang-mode
-      "C-c C-t" 'erl-trace-insert
-      "C-c C-e" 'erl-trace-run-cmd
-      "C-c C-r" 'erl-trace-store
-      ))
-  )
+    :commands (erl-trace-insert erl-trace-run-cmd erl-trace-store)))
 
-(defun erlang_ts/post-init-flycheck ()
-  (spacemacs/enable-flycheck 'erlang-mode))
-
-
-(defun erlang_ts/post-init-edts ()
-  (unless (ignore-errors (require 'edts-start))
-    (warn "EDTS is not installed in this environment!")))
+(defun erlang_ts/init-cmpload ()
+  (use-package cmpload
+    :defer t
+    :commands (cmpload-load cmpload-reload cmpload-compile)))


### PR DESCRIPTION
Refactor the Erlang Spacemacs layer to align with guidelines, improve robustness, and add new Erlang development features.

This PR introduces a standard Spacemacs layer structure, making package initialization more robust by gracefully handling missing optional dependencies. It also expands Erlang development support with new tools like EDTS, erl-trace, cmpload, and rebar3 helpers, all documented in an updated README.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed6d907d-c44a-49b0-a6a2-c60eb2c5f87d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed6d907d-c44a-49b0-a6a2-c60eb2c5f87d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

